### PR TITLE
Clarify link to UCSF Policies

### DIFF
--- a/PyBay/content/health-and-safety/contents.lr
+++ b/PyBay/content/health-and-safety/contents.lr
@@ -22,7 +22,7 @@ We will have masks available at the conference for anyone who needs them. It is 
 
 While we follow San Francisco's guidance for this event and don't require masks or proof of vaccination, we respect individual choices. Please prioritize hygiene, personal space, and your health. Stay home if unwell. Your safety matters most as we enjoy the event together.
 
-At a minimum, we will be following all mandated policies of the venue (UCSF Mission Bay is the conference venue  in 2024 [UCSF policy here [https://coronavirus.ucsf.edu/events](https://coronavirus.ucsf.edu/events) ]), in addition to municipal and state guidelines. This list, and all protocols, are subject to change if the COVID-19 situation changes.
+At a minimum, we will be following all mandated policies of the venue (UCSF Mission Bay is the conference venue  in 2024 [UCSF policy available at [https://coronavirus.ucsf.edu/events](https://coronavirus.ucsf.edu/events)), in addition to municipal and state guidelines. This list, and all protocols, are subject to change if the COVID-19 situation changes.
 
 
 #### **Vaccine Guideline**


### PR DESCRIPTION
Combine two branches both intended to clarify the link to the UCSF COVID Precautions page in the event's safety policy